### PR TITLE
Add Cursor Cloud specific instructions to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -185,3 +185,43 @@ Rust, C, F#.
 2. Add a `_category_.json` with `label` and optional `generatedIndex`
 3. Add the directory name to the parent's array in `sidebar-order.ts`
 4. Run `pnpm build` to verify
+
+## Cursor Cloud specific instructions
+
+### Environment prerequisites
+
+Node.js 22 and pnpm 10.x are required. The VM update script installs these
+automatically via NodeSource and corepack. No additional system dependencies
+are needed.
+
+### Running the dev server
+
+```bash
+pnpm start --host 0.0.0.0 --port 3000
+```
+
+Use `--host 0.0.0.0` so the site is accessible from the Desktop browser pane.
+The dev server supports hot reload; editing any `.md`, `.mdx`, `.ts`, `.css`,
+or config file triggers an automatic rebuild.
+
+### Verification workflow
+
+There is no test suite. The verification steps are:
+
+1. `pnpm build` -- the only "test". Fails on broken links, anchors, or images.
+2. `pnpm start` -- visually confirm the site renders correctly in a browser.
+
+### Gotchas
+
+- **No lockfile in repo**: `pnpm-lock.yaml` is gitignored. `pnpm install`
+  generates it fresh each time. This means dependency versions may drift
+  between environments; `pnpm build` is the gate.
+- **`.nvmrc` says v16**: Ignore it. The correct Node version is `^22` per
+  `engines` in `package.json`.
+- **No ESLint / Prettier**: There are no JS/TS linters configured. The only
+  prose linter is Vale (optional, not installed in the Cloud VM by default).
+- **SWC build warnings**: The `vscode-languageserver-types` critical dependency
+  warning during `pnpm build` is benign and can be ignored.
+- **Algolia and Umami**: Both are external services configured with public
+  client-side keys. They are non-functional in local dev (Umami is skipped on
+  localhost). No secrets are needed.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a `## Cursor Cloud specific instructions` section to `AGENTS.md` with environment prerequisites, dev server startup notes, verification workflow, and non-obvious gotchas discovered during environment setup.

### Changes
- Added Cloud-specific instructions covering Node.js/pnpm setup, dev server flags, verification workflow, and known gotchas (no lockfile in repo, outdated `.nvmrc`, SWC build warnings, etc.)

### Evidence of working environment

[docusaurus_dev_server_demo.mp4](https://cursor.com/agents/bc-8f5eb0f8-02b8-4745-8709-9bf218c1036f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdocusaurus_dev_server_demo.mp4)
Dev server running with hot reload, navigating through homepage, AEM category, and Architecture article.

[Homepage](https://cursor.com/agents/bc-8f5eb0f8-02b8-4745-8709-9bf218c1036f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhomepage.webp)
[AEM category page](https://cursor.com/agents/bc-8f5eb0f8-02b8-4745-8709-9bf218c1036f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Faem_category.webp)
[AEM Architecture article with Mermaid diagram](https://cursor.com/agents/bc-8f5eb0f8-02b8-4745-8709-9bf218c1036f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Faem_architecture_article.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8f5eb0f8-02b8-4745-8709-9bf218c1036f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8f5eb0f8-02b8-4745-8709-9bf218c1036f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

